### PR TITLE
Set `default_auto_field` to `django.db.models.AutoField` in HeraldConfig

### DIFF
--- a/herald/apps.py
+++ b/herald/apps.py
@@ -11,6 +11,7 @@ class HeraldConfig(AppConfig):
     Django app config for herald. Using this to call autodiscover
     """
 
+    default_auto_field = "django.db.models.AutoField"
     name = "herald"
 
     def ready(self):


### PR DESCRIPTION
This ensures that if a Django project uses `django-heralder` and has their `settings.DEFAULT_AUTO_FIELD` set to any value other than `django.db.models.AutoField`, `Notification` and `SentNotification`'s primary key fields are unaffected.

Fixes #28 